### PR TITLE
Addiding initial UI for accepted answers

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -115,12 +115,14 @@ module.exports = function (Topics) {
             return _.zipObject(uids, userData);
         }
         const [
+            accepts,
             bookmarks,
             voteData,
             userData,
             editors,
             replies,
         ] = await Promise.all([
+            posts.hasAccepted(pids, uid),
             posts.hasBookmarked(pids, uid),
             posts.getVoteStatusByPostIDs(pids, uid),
             getPostUserData('uid', async uids => await posts.getUserInfoForPosts(uids, uid)),
@@ -133,6 +135,7 @@ module.exports = function (Topics) {
             if (postObj) {
                 postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
                 postObj.editor = postObj.editor ? editors[postObj.editor] : null;
+                postObj.accepted = accepts[i];
                 postObj.bookmarked = bookmarks[i];
                 postObj.upvoted = voteData.upvotes[i];
                 postObj.downvoted = voteData.downvotes[i];

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -52,7 +52,6 @@
 <div class="content" component="post/content" itemprop="text">
     {posts.content}
 </div>
-
 <div class="post-footer">
     {{{ if posts.user.signature }}}
     <div component="post/signature" data-uid="{posts.user.uid}" class="post-signature">{posts.user.signature}</div>
@@ -77,11 +76,12 @@
     {{{ end }}}
 
     <small class="pull-right">
+        <i class="fa fa-check-circle <!-- IF !posts.accepted -->hidden<!-- ENDIF !posts.accepted -->"></i>
         <!-- IMPORT partials/topic/reactions.tpl -->
         <span class="post-tools">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <a component="post/accept" href="#" data-accepted="false" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:accept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:accept]]</a>
         </span>
 
         <!-- IF !reputation:disabled -->


### PR DESCRIPTION
## What

This PR adds some frontend and backend code that allows the displays when an answer has been accepted. See this screenshot for noticing changes:

## Why

As part of our redesign of NodeBB to be more of a question answering platform, we want there to be a way for people asking question to mark which answers actually fixed their issue to was best. (For example, see StackOverflow).
## How

Among the changes in this PR to achieve the intended purpose are:
- modifying existing template files
- modifying the post object such that it can return when a post has been accepted

## Future work
There as still some things to be worked out such that we can resolve the corresponding issue:
- make the accepted button only visible to owners of a question
- add a confirmation pop-up when the accepted button is clicked
- make the accepted button change colors or change to "unaccept" once clicked
- make the check appear when other people log in
- make the accepted button only appear for answers not questions
- A collection of ui changes:
    - make the check more prominent
    - (optional or alternatively) change the background color of a post if it has been accepted
