### PR TITLE
modifying post search bar to make post search easier to implement

### DIFF
--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -9,11 +9,9 @@
             <div class="col-lg-3 col-xs-9">
 
                 <div class="input-group">
-                    <input class="form-control" id="search-user" type="text" placeholder="Search for post"/>
+                    <input class="form-control" id="search-post" type="text" placeholder="Search for post"/>
                     <span class="input-group-addon">
-                        <a href="https://www.google.com" id="search-icon-link">
-                            <i component="user/search/icon" class="fa fa-search"></i>
-                        </a>                   
+                        <i component="user/search/icon" class="fa fa-search"></i>
                     </span>
                 </div>
         


### PR DESCRIPTION
## What

This tiny PR makes some front-end modifications to the search bar for posts to make implementing the backend for search easier.
## Why

We want to be able to access the values of search queries, so that implementing backend for searching posts is easier. Searching for posts will save students time.
## How

This PR did two things:
* gave the search bar a unique element id
* removed an anchor tag that redirected to google.com