### PR TITLE
Hidding accept button from questions

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -81,7 +81,7 @@
         <span class="post-tools">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:accept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.topicOwnerPost -->hidden<!-- ENDIF  posts.topicOwnerPost -->">[[topic:accept]]</a>
         </span>
 
         <!-- IF !reputation:disabled -->


### PR DESCRIPTION
## What

This PR hides the accept button from questions

## Why

questions cannot be answers, so it does not make sense in terms of user experience to have it as an option with questions
## How

this was a simple change with by adding an if statement in a template file.