### PR TITLE
Accepted answer post priviledges

### DIFF
--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -221,11 +221,15 @@ get:
                           type: boolean
                         topicOwnerPost:
                           type: boolean
+                        isTopicOwner:
+                          type: boolean
                         display_edit_tools:
                           type: boolean
                         display_delete_tools:
                           type: boolean
                         display_moderator_tools:
+                          type: boolean
+                        display_accept_button:
                           type: boolean
                         display_move_tools:
                           type: boolean

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -56,11 +56,14 @@ define('forum/topic/posts', [
     Posts.modifyPostsByPrivileges = function (posts) {
         posts.forEach(function (post) {
             post.selfPost = !!app.user.uid && parseInt(post.uid, 10) === parseInt(app.user.uid, 10);
-            post.topicOwnerPost = parseInt(post.uid, 10) === parseInt(ajaxify.data.uid, 10);
+            post.isTopicOwner = parseInt(topicPrivileges.uid, 10) == parseInt(topicData.uid, 10);
+            post.topicOwnerPost = parseInt(topicData.uid, 10) === parseInt(post.uid, 10);
+
 
             post.display_edit_tools = (ajaxify.data.privileges['posts:edit'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
             post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
             post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
+            post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner;
             post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
             post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
                 (post.selfPost && !ajaxify.data.locked && !post.deleted) ||

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -56,14 +56,10 @@ define('forum/topic/posts', [
     Posts.modifyPostsByPrivileges = function (posts) {
         posts.forEach(function (post) {
             post.selfPost = !!app.user.uid && parseInt(post.uid, 10) === parseInt(app.user.uid, 10);
-            post.isTopicOwner = parseInt(topicPrivileges.uid, 10) == parseInt(topicData.uid, 10);
-            post.topicOwnerPost = parseInt(topicData.uid, 10) === parseInt(post.uid, 10);
-
 
             post.display_edit_tools = (ajaxify.data.privileges['posts:edit'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
             post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
             post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
-            post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner;
             post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
             post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
                 (post.selfPost && !ajaxify.data.locked && !post.deleted) ||

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -237,6 +237,7 @@ module.exports = function (Topics) {
         postData.display_edit_tools = true;
         postData.display_delete_tools = true;
         postData.display_moderator_tools = true;
+        postData.display_accept_button = true;
         postData.display_move_tools = true;
         postData.selfPost = false;
         postData.timestampISO = utils.toISOString(postData.timestamp);

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -162,10 +162,12 @@ module.exports = function (Topics) {
         const loggedIn = parseInt(topicPrivileges.uid, 10) > 0;
         topicData.posts.forEach((post) => {
             if (post) {
+                post.isTopicOwner = parseInt(topicPrivileges.uid, 10) == parseInt(topicData.uid, 10);
                 post.topicOwnerPost = parseInt(topicData.uid, 10) === parseInt(post.uid, 10);
                 post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
                 post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);
                 post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
+                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner;
                 post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
                 post.display_post_menu = topicPrivileges.isAdminOrMod ||
                     (post.selfPost &&

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -162,7 +162,7 @@ module.exports = function (Topics) {
         const loggedIn = parseInt(topicPrivileges.uid, 10) > 0;
         topicData.posts.forEach((post) => {
             if (post) {
-                post.isTopicOwner = parseInt(topicPrivileges.uid, 10) == parseInt(topicData.uid, 10);
+                post.isTopicOwner = parseInt(topicPrivileges.uid, 10) === parseInt(topicData.uid, 10);
                 post.topicOwnerPost = parseInt(topicData.uid, 10) === parseInt(post.uid, 10);
                 post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
                 post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -81,7 +81,7 @@
         <span class="post-tools">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.topicOwnerPost -->hidden<!-- ENDIF  posts.topicOwnerPost -->">[[topic:accept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF !posts.display_accept_button -->hidden<!-- ENDIF  !posts.display_accept_button -->">[[topic:accept]]</a>
         </span>
 
         <!-- IF !reputation:disabled -->


### PR DESCRIPTION
## What

This PR adds logic to restrict the accepted answer button from appearing only the appropriate situations.

## Why

The previous implementation of the accepted answers showed the accept button under all posts, when it should only be answer (not questions) and should only be visible for owners of posts (users that are not question owners should not be able to accept posts).

## How

added post variables in appropriate files in the same place where all other post privilege variables are.
