### PR TITLE
Accepted answers pop-up

### DIFF
--- a/public/language/en-GB/global.json
+++ b/public/language/en-GB/global.json
@@ -21,6 +21,9 @@
 
 	"welcome_back": "Welcome Back ",
 	"you_have_successfully_logged_in": "You have successfully logged in",
+	"answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer",
+
 
 	"save_changes": "Save Changes",
 	"save": "Save",

--- a/public/language/en-GB/global.json
+++ b/public/language/en-GB/global.json
@@ -22,7 +22,7 @@
 	"welcome_back": "Welcome Back ",
 	"you_have_successfully_logged_in": "You have successfully logged in",
 	"answer_accepted_title": "Answer Accepted",
-	"answer_accepted_message": "You have successfully accepted answer",
+	"answer_accepted_message": "You have successfully accepted answer!",
 
 
 	"save_changes": "Save Changes",

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -372,8 +372,8 @@ define('forum/topic/postTools', [
         });
         alerts.alert({
             type: 'success',
-            title: '[[global:answer_accepted_title]] ' + app.user.username + '!',
-            message: '[[global:answer_accepted_message]',
+            title: '[[global:answer_accepted_title]] !',
+            message: '[[global:answer_accepted_message]]',
             timeout: 5000,
         });
         return false;

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -370,6 +370,12 @@ define('forum/topic/postTools', [
             const type = method === 'put' ? 'accept' : 'unaccept';
             hooks.fire(`action:post.${type}`, { pid: pid });
         });
+        alerts.alert({
+            type: 'success',
+            title: '[[global:answer_accepted_title]] ' + app.user.username + '!',
+            message: '[[global:answer_accepted_message]',
+            timeout: 5000,
+        });
         return false;
     }
 

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -167,9 +167,7 @@ module.exports = function (Topics) {
                 post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
                 post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);
                 post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
-                post.hide_accept_button = post.display_moderator_tools || post.topicOwnerPost || !post.isTopicOwner;
-                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && !post.accepted;
-                post.display_unaccept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && post.accepted;
+                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner;
                 post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
                 post.display_post_menu = topicPrivileges.isAdminOrMod ||
                     (post.selfPost &&

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -167,7 +167,9 @@ module.exports = function (Topics) {
                 post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
                 post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);
                 post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
+                post.hide_accept_button = post.display_moderator_tools || post.topicOwnerPost || !post.isTopicOwner;
                 post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && !post.accepted;
+                post.display_unaccept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && post.accepted;
                 post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
                 post.display_post_menu = topicPrivileges.isAdminOrMod ||
                     (post.selfPost &&

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -167,7 +167,7 @@ module.exports = function (Topics) {
                 post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
                 post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);
                 post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
-                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && post.accepted;
+                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && !post.accepted;
                 post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
                 post.display_post_menu = topicPrivileges.isAdminOrMod ||
                     (post.selfPost &&

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -167,7 +167,7 @@ module.exports = function (Topics) {
                 post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
                 post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);
                 post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
-                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner;
+                post.display_accept_button = !post.display_moderator_tools && !post.topicOwnerPost && post.isTopicOwner && post.accepted;
                 post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
                 post.display_post_menu = topicPrivileges.isAdminOrMod ||
                     (post.selfPost &&

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -82,6 +82,8 @@
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
             <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF !posts.display_accept_button -->hidden<!-- ENDIF  !posts.display_accept_button -->">[[topic:accept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.display_accept_button -->hidden<!-- ENDIF  posts.display_accept_button -->">[[topic:unaccept]]</a>
+
         </span>
 
         <!-- IF !reputation:disabled -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -81,8 +81,10 @@
         <span class="post-tools">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF !posts.display_accept_button -->hidden<!-- ENDIF  !posts.display_accept_button -->">[[topic:accept]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.display_accept_button -->hidden<!-- ENDIF  posts.display_accept_button -->">[[topic:unaccept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.hide_accept_button -->hidden<!-- ENDIF  posts.hide_accept_button -->">[[topic:Accept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.display_accept_button -->hidden<!-- ENDIF  posts.display_accept_button -->">[[topic:Accept]]</a>
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.display_unaccept_button -->hidden<!-- ENDIF  posts.display_unaccept_button -->">[[topic:Unaccept]]</a>
+
 
         </span>
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -81,10 +81,7 @@
         <span class="post-tools">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.hide_accept_button -->hidden<!-- ENDIF  posts.hide_accept_button -->">[[topic:Accept]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.display_accept_button -->hidden<!-- ENDIF  posts.display_accept_button -->">[[topic:Accept]]</a>
-            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF posts.display_unaccept_button -->hidden<!-- ENDIF  posts.display_unaccept_button -->">[[topic:Unaccept]]</a>
-
+            <a component="post/accept" href="#" data-accepted="{posts.accepted}" class="no-select <!-- IF !posts.display_accept_button -->hidden<!-- ENDIF  !posts.display_accept_button -->">[[topic:Accept]]</a>
 
         </span>
 


### PR DESCRIPTION
**What** 
This PR creates a pop up that appears immediately after a user accepts a post. This PR resolves the second bullet point in the "Future Work" section of PR #24.
**Why**
We wanted there to be some form of immediate feedback when the user accepts an answer. Future work could include refreshing the page on clicking the accept button to make the changes immediately visible.
**How**
Created new messages in the global.json file, and utilized those messages in an alert included inside postTools.js.

<img width="942" alt="Screenshot 2024-02-28 at 2 52 50 PM" src="https://github.com/CMU-313/spring24-nodebb-ratramen/assets/118159750/e1d740fb-cfdb-4df3-979b-eb884a69f999">
