### PR TITLE
added temporary values for acecpted answer translations

### DIFF
--- a/public/language/ar/global.json
+++ b/public/language/ar/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "إضافة مشاركات جديد حكر على الأعضاء المسجلين، انقر هنا لتسجيل الدخول.",
     "welcome_back": "مرحبًا بعودتك",
     "you_have_successfully_logged_in": "تم سجيل الدخول بنجاح",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "حفظ التغييرات",
     "save": "حفظ",
     "close": "أغلق",

--- a/public/language/bg/global.json
+++ b/public/language/bg/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Публикуването в момента е позволено само за регистрираните потребители. Натиснете тук, за да се впишете.",
     "welcome_back": "Добре дошли отново",
     "you_have_successfully_logged_in": "Вие влязохте успешно",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Запазване на промените",
     "save": "Запазване",
     "close": "Затваряне",

--- a/public/language/bn/global.json
+++ b/public/language/bn/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "বর্তমানে নিবন্ধিত সদস্যরাই কেবল পোস্ট করতে পারেন, লগ ইন করতে এখানে ক্লিক করুন।",
     "welcome_back": "আপনাকে স্বাগতম",
     "you_have_successfully_logged_in": "আপনি সফলভাবে প্রবেশ করেছেন",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "পরিবর্তনগুলি সঞ্চয় করুন",
     "save": "Save",
     "close": "বন্ধ",

--- a/public/language/cs/global.json
+++ b/public/language/cs/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "V současné době je zasílání příspěvků povoleno pouze registrovaným členům, klikněte zde a přihlašte se.",
     "welcome_back": "Vítejte zpět",
     "you_have_successfully_logged_in": "Vaše přihlášení proběhlo úspěšně",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Uložit změny",
     "save": "Uložit",
     "close": "Zrušit",

--- a/public/language/da/global.json
+++ b/public/language/da/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Det er i øjeblikket kun muligt at skrive indlæg som registeret medlem, klik her for at logge ind.",
     "welcome_back": "Velkommen tilbage",
     "you_have_successfully_logged_in": "Du er nu logget ind",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Gem ændringer",
     "save": "Save",
     "close": "Luk",

--- a/public/language/de/global.json
+++ b/public/language/de/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Nur registrierte Mitglieder dürfen Beiträge verfassen. Hier klicken zum Anmelden.",
     "welcome_back": "Willkommen zurück",
     "you_have_successfully_logged_in": "Du hast dich erfolgreich angemeldet",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Änderungen speichern",
     "save": "Speichern",
     "close": "Schließen",

--- a/public/language/el/global.json
+++ b/public/language/el/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Η δημοσίευση είναι περιορισμένη μόνο για εγγεγραμμένα μέλη, κάνε κλικ εδώ για να συνδεθείς.",
     "welcome_back": "Καλωσόρισες Πάλι",
     "you_have_successfully_logged_in": "Συνδέθηκες με επιτυχία",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Αποθήκευση Αλλαγών",
     "save": "Αποθήκευση",
     "close": "Κλείσιμο",

--- a/public/language/en-US/global.json
+++ b/public/language/en-US/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Posting is currently restricted to registered members only, click here to log in.",
     "welcome_back": "Welcome Back",
     "you_have_successfully_logged_in": "You have successfully logged in",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Save Changes",
     "save": "Save",
     "close": "Close",

--- a/public/language/en-x-pirate/global.json
+++ b/public/language/en-x-pirate/global.json
@@ -17,6 +17,8 @@
     "logout": "Logout",
     "posting_restriction_info": "Postin' be currently restricted to registered members only, click here to log in.",
     "welcome_back": "Welcome Back",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "you_have_successfully_logged_in": "Ye have successfully logged in",
     "save_changes": "Save yer Changes",
     "save": "Save",

--- a/public/language/es/global.json
+++ b/public/language/es/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Para publicar se requiere ser usuario registrado, conéctate o regístrate.",
     "welcome_back": "¡Bienvenido de nuevo!",
     "you_have_successfully_logged_in": "Identificado satisfactoriamente",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Guardar cambios",
     "save": "Guardar",
     "close": "Cerrar",

--- a/public/language/et/global.json
+++ b/public/language/et/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Siin foorumis on postitamine lubatud ainult registreeritud kasutajatel, palun logi sisse.",
     "welcome_back": "Tere tulemast tagasi!",
     "you_have_successfully_logged_in": "Edukalt sisse logitud",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Salvesta muudatused",
     "save": "Save",
     "close": "Sulge",

--- a/public/language/fa-IR/global.json
+++ b/public/language/fa-IR/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "دیدگاه گذاستن هم‌اکنون به اعضا محدود شده است، برای درون آمدن اینجا را بفشارید.",
     "welcome_back": "خوش آمدید",
     "you_have_successfully_logged_in": "با موفقیت درون آمده‌اید",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "اندوختن تغییرها",
     "save": "ذخیره",
     "close": "بستن",

--- a/public/language/fi/global.json
+++ b/public/language/fi/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Kirjoittaminen on tällä hetkellä rajattu vain rekisteröityneille käyttäjille. Napsauta tätä kirjautuaksesi.",
     "welcome_back": "Tervetuloa takaisin",
     "you_have_successfully_logged_in": "Olet onnistuneesti kirjautunut sisään",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Tallenna muutokset",
     "save": "Tallenna",
     "close": "Sulje",

--- a/public/language/fr/global.json
+++ b/public/language/fr/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "L'envoi de messages est réservé aux membres inscrits, cliquez ici pour vous connecter.",
     "welcome_back": "Bienvenue",
     "you_have_successfully_logged_in": "Vous vous êtes bien connecté",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Enregistrer les changements",
     "save": "Enregistrer",
     "close": "Fermer",

--- a/public/language/gl/global.json
+++ b/public/language/gl/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "As publicacións están restrinxidas a membros rexistrados, pica aquí para rexistrarte.",
     "welcome_back": "Benvido de novo!",
     "you_have_successfully_logged_in": "Sentidiño!",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Gardar Cambios",
     "save": "Gardar",
     "close": "Pechar ",

--- a/public/language/hr/global.json
+++ b/public/language/hr/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Objave su trenutačno omogućene samo registriranim korisnicima,kliknite ovdje za prijavu.",
     "welcome_back": "Dobrodošli natrag",
     "you_have_successfully_logged_in": "Uspješno ste se prijavili",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Spremi promjene",
     "save": "Spremi",
     "close": "Zatvori",

--- a/public/language/hu/global.json
+++ b/public/language/hu/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "A hozzászólás regisztrációhoz kötött, kérlek kattints ide a belépéshez.",
     "welcome_back": "Üdvözlünk újra közöttünk",
     "you_have_successfully_logged_in": "Sikeresen beléptél",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Változások mentése",
     "save": "Mentés",
     "close": "Bezárás",

--- a/public/language/hy/global.json
+++ b/public/language/hy/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Գրառումները ներկայումս սահմանափակված են միայն գրանցված անդամների համար: Մուտք գործելու համար սեղմեք այստեղ:",
     "welcome_back": "Բարի վերադարձ",
     "you_have_successfully_logged_in": "Դուք հաջողությամբ մուտք գործեցիք",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Պահպանել փոփոխությունները",
     "save": "Պահպանել",
     "close": "Փակել",

--- a/public/language/id/global.json
+++ b/public/language/id/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Posting hanya boleh dilakukan oleh pengguna terdaftar, klik disini untuk log in.",
     "welcome_back": "Selamat Datang Kembali",
     "you_have_successfully_logged_in": "Kamu sudah login",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Menyimpan perubahan",
     "save": "Save",
     "close": "Tutup",

--- a/public/language/it/global.json
+++ b/public/language/it/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "L'inserimento di nuovi post è attualmente limitato ai soli utenti registrati, clicca qui per effettuare l'accesso.",
     "welcome_back": "Bentornato",
     "you_have_successfully_logged_in": "Accesso effettuato con successo",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Salva Modifiche",
     "save": "Salva",
     "close": "Chiudi",

--- a/public/language/ja/global.json
+++ b/public/language/ja/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "登録ユーザーのみが投稿可能となります.こちらからログインください。",
     "welcome_back": "おかえりなさい",
     "you_have_successfully_logged_in": "ログインできました",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "保存する",
     "save": "保存",
     "close": "閉じる",

--- a/public/language/ko/global.json
+++ b/public/language/ko/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "현재 회원들만 작성할 수 있습니다. 여기를 누르면 로그인 페이지로 이동합니다.",
     "welcome_back": "환영합니다.",
     "you_have_successfully_logged_in": "성공적으로 로그인했습니다.",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "변경사항 저장",
     "save": "저장",
     "close": "닫기",

--- a/public/language/lt/global.json
+++ b/public/language/lt/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Naujų pranešimų kūrimas galimas tik registruotiems vartotojams. Spauskite čia norėdami prisijungti.",
     "welcome_back": "Sveiki sugrįžę",
     "you_have_successfully_logged_in": "Jūs sėkmingai prisijungėte",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Išsaugoti pakeitimus",
     "save": "Save",
     "close": "Uždaryti",

--- a/public/language/lv/global.json
+++ b/public/language/lv/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Pašlaik publicēšana pieejama tikai reģistrētiem biedriem, lai ielogotos, noklikšķini šeit.",
     "welcome_back": "Sveiks atpakaļ",
     "you_have_successfully_logged_in": "Tu esi veiksmīgi ielogojies",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Saglabāt izmaiņas",
     "save": "Saglabāt",
     "close": "Aizvērt",

--- a/public/language/ms/global.json
+++ b/public/language/ms/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Kiriman terhad kepada pengguna berdaftar sahaja, Sila click disini untuk daftar masuk",
     "welcome_back": "Selamat kembali",
     "you_have_successfully_logged_in": "Anda telah berjaya log masuk",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Simpan perubahan",
     "save": "Save",
     "close": "Tutup",

--- a/public/language/nb/global.json
+++ b/public/language/nb/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Posting er foreløpig begrenset til registrerte medlemmer, klikk her for å logge inn.",
     "welcome_back": "Velkommen tilbake",
     "you_have_successfully_logged_in": "Du har blitt logget inn",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Lagre endringer",
     "save": "Lagre",
     "close": "Lukk",

--- a/public/language/nl/global.json
+++ b/public/language/nl/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Reageren is momenteel beperkt tot geregistreerde leden, klik hier om in te loggen.",
     "welcome_back": "Welkom terug",
     "you_have_successfully_logged_in": "Aanmelden succesvol",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Wijzigingen opslaan",
     "save": "Opslaan",
     "close": "Sluiten",

--- a/public/language/pl/global.json
+++ b/public/language/pl/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Posty mogą pisać tylko zarejestrowani użytkownicy forum. Kliknij tutaj, aby się zalogować.",
     "welcome_back": "Witaj ponownie,",
     "you_have_successfully_logged_in": "Logowanie powiodło się.",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Zapisz zmiany",
     "save": "Zapisz",
     "close": "Zamknij",

--- a/public/language/pt-BR/global.json
+++ b/public/language/pt-BR/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "A postagem está restrita apenas à membros registrados, clique aqui para logar.",
     "welcome_back": "Bem-vindo de volta",
     "you_have_successfully_logged_in": "Você logou com sucesso",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Salvar Alterações",
     "save": "Salvar",
     "close": "Fechar",

--- a/public/language/pt-PT/global.json
+++ b/public/language/pt-PT/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Publicar está, neste momento, apenas restrito a membros registados, clica aqui para iniciares sessão.",
     "welcome_back": "Bem-vindo de volta",
     "you_have_successfully_logged_in": "Iniciaste sessão com sucesso",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Guardar as alterações",
     "save": "Guardar",
     "close": "Fechar",

--- a/public/language/ro/global.json
+++ b/public/language/ro/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Pentru a posta trebuie să fi înregistrat. Apasă aici pentru a te atentifica.",
     "welcome_back": "Bine ai revenit",
     "you_have_successfully_logged_in": "Te-ai conectat cu succes",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Salvează Modificări",
     "save": "Save",
     "close": "Închide",

--- a/public/language/ru/global.json
+++ b/public/language/ru/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Сообщения могут оставлять только зарегистрированные участники. Нажмите сюда, чтобы войти на сайт",
     "welcome_back": "С возвращением!",
     "you_have_successfully_logged_in": "Вы успешно вошли на форум",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Сохранить изменения",
     "save": "Сохранить",
     "close": "Закрыть",

--- a/public/language/rw/global.json
+++ b/public/language/rw/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Gushyiraho ikintu byemewe ku banyamuryango gusa. Niba uri we, kanda hano winjiremo. ",
     "welcome_back": "Urakaza Neza Urisanga",
     "you_have_successfully_logged_in": "Winjiyemo nta ngorane",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Bika ibyamaze gukorwa",
     "save": "Save",
     "close": "Funga",

--- a/public/language/sc/global.json
+++ b/public/language/sc/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Sa publicatzione immoe est limitada isceti a is impitadores registrados, carca inoghe pro intrare.",
     "welcome_back": "Welcome Back",
     "you_have_successfully_logged_in": "Ses intradu",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Alloga Acontzos",
     "save": "Save",
     "close": "Serra",

--- a/public/language/sk/global.json
+++ b/public/language/sk/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "V súčasnej dobe je zasielanie príspevkov povolené len registrovaným používateľom, kliknite sem a prihláste sa.",
     "welcome_back": "Vitajte späť",
     "you_have_successfully_logged_in": "Úspešne ste sa prihlásili",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Uložiť zmeny",
     "save": "Uložiť",
     "close": "Zatvoriť",

--- a/public/language/sl/global.json
+++ b/public/language/sl/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Objavljanje je trenutno omogočeno le registriranim članom, kliknite tu za prijavo.",
     "welcome_back": "Dobrodošli nazaj!",
     "you_have_successfully_logged_in": "Uspešno ste se prijavili.",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Shrani spremembe.",
     "save": "Shrani",
     "close": "Zapri",

--- a/public/language/sq-AL/global.json
+++ b/public/language/sq-AL/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Postimi aktualisht është i kufizuar vetëm për anëtarët e regjistruar, klikoni këtu për t'u identifikuar.",
     "welcome_back": "Mirë se u kthyet",
     "you_have_successfully_logged_in": "Ju keni hyrë me sukses",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Ruaj ndryshimet",
     "save": "Ruaj",
     "close": "Mbyll",

--- a/public/language/sr/global.json
+++ b/public/language/sr/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Слање порука је тренутно ограничено само на пријављене кориснике, кликните овде да се пријавите.",
     "welcome_back": "Добродошли поново",
     "you_have_successfully_logged_in": "Успешно сте се пријавили",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Сачувај измене",
     "save": "Сачувај",
     "close": "Затвори",

--- a/public/language/sv/global.json
+++ b/public/language/sv/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Man måste vara inloggad för att kunna skapa inlägg, klicka här för att logga in.",
     "welcome_back": "Välkommen tillbaka ",
     "you_have_successfully_logged_in": "Inloggningen lyckades",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Spara ändringar",
     "save": "Spara",
     "close": "Stäng",

--- a/public/language/th/global.json
+++ b/public/language/th/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "คุณต้องเป็นสมาชิกเพื่อทำการโพสต์ คลิกที่นี่เพื่อเข้าสู่ระบบ",
     "welcome_back": "ยินดีต้อนรับ",
     "you_have_successfully_logged_in": "คุณได้เข้าสู่ระบบแล้ว",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "บันทึกการเปลี่ยนแปลง",
     "save": "บันทึก",
     "close": "ปิด",

--- a/public/language/tr/global.json
+++ b/public/language/tr/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "İleti gönderme sadece kayıtlı kullanıcılar içindir, giriş yapmak için buraya tıklayın.",
     "welcome_back": "Tekrar Hoş Geldiniz",
     "you_have_successfully_logged_in": "Başarıyla giriş yaptınız!",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Değişiklikleri Kaydet",
     "save": "Kaydet",
     "close": "Kapat",

--- a/public/language/uk/global.json
+++ b/public/language/uk/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Наразі постити можуть лише зареєстровані користувачі, натисніть тут щоб увійти.",
     "welcome_back": "З поверненням",
     "you_have_successfully_logged_in": "Ви успішно увійшли",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Зберегти зміни",
     "save": "Зберегти",
     "close": "Закрити",

--- a/public/language/vi/global.json
+++ b/public/language/vi/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "Chỉ thành viên chính thức mới được phép đăng bài, nhấn vào đây để đăng nhập.",
     "welcome_back": "Chào mừng bạn quay lại",
     "you_have_successfully_logged_in": "Bạn đã đăng nhập thành công",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "Lưu thay đổi",
     "save": "Lưu",
     "close": "Đóng",

--- a/public/language/zh-CN/global.json
+++ b/public/language/zh-CN/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "仅限于注册会员发帖，点这里登录。",
     "welcome_back": "欢迎回来",
     "you_have_successfully_logged_in": "您已成功登录",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "保存更改",
     "save": "保存",
     "close": "关闭",

--- a/public/language/zh-TW/global.json
+++ b/public/language/zh-TW/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "僅限已註冊成員發文，點這裡登入。",
     "welcome_back": "歡迎回來",
     "you_have_successfully_logged_in": "您已成功登入",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "儲存更改",
     "save": "儲存",
     "close": "關閉",


### PR DESCRIPTION
## What


This PR adds temporary English values for translations of various languages to the the accepted answer pop-up messages.

## Why

Our GitHub test suite was failing after PR #31 was merged. It seems like this was due to lack of translation for the messages that were added. Given our project deadlines, we will temporarily add English values to all translations

## Future work

Future work should attempt to actually translate all these values.