### PR TITLE
added hewbrew temp values

### DIFF
--- a/public/language/he/global.json
+++ b/public/language/he/global.json
@@ -18,6 +18,8 @@
     "posting_restriction_info": "כתיבת פוסטים מאופשר למשתמשים רשומים בלבד, לחצו כאן כדי להתחבר.",
     "welcome_back": "ברוך שובך",
     "you_have_successfully_logged_in": "התחברתם בהצלחה",
+    "answer_accepted_title": "Answer Accepted",
+	"answer_accepted_message": "You have successfully accepted answer!",
     "save_changes": "שמור שינויים",
     "save": "שמור",
     "close": "סגור",


### PR DESCRIPTION
## What

This PR adds temporary English values for translations of hebrew to the the accepted answer pop-up messages.
## Why

Our GitHub test suite was failing after PR https://github.com/CMU-313/spring24-nodebb-ratramen/pull/31 was merged. It seems like this was due to lack of translation for the messages that were added. Given our project deadlines, we will temporarily add English values to all translations. A previous PR missed this language, so the tests were still failing
## Future work

Future work should attempt to actually translate all these values.