### PR TITLE
Ran Hegel static analysis tool

### DIFF
--- a/.hegelrc
+++ b/.hegelrc
@@ -1,0 +1,7 @@
+include:
+  - ./**/*.js
+exclude:
+  - ./node_modules/**
+types:
+  - ./@types
+  - ./node_modules/@types


### PR DESCRIPTION
Ran the Hegel static analysis tool (https://hegel.js.org/docs). Hegel is primarily a static type checker for JS, allowing users to identify type-related bugs faster and without needing to run their program. Hegel also checks for basic syntax errors in JS. Below is the output from running Hegel with all of the NodeBB codebase:
<img width="591" alt="Screenshot 2024-03-14 at 1 55 16 PM" src="https://github.com/CMU-313/spring24-nodebb-ratramen/assets/118159750/31404671-1cc7-4b51-9363-a79e0f05223e">
And below is the output from running a single file (/build/public/src/client/topic/postTools.js):
<img width="494" alt="Screenshot 2024-03-14 at 5 34 44 PM" src="https://github.com/CMU-313/spring24-nodebb-ratramen/assets/118159750/ab2a784b-88b5-4ab0-b13c-5a660a365013">

Given how little information was given in the first screenshot, it is best to use Hegel for individual files like the above postTools.jsin a codebase. The errors in the postTools.js analysis output are possibly from the discrepancy between NodeJS in the code and plain JS used by Hegel, but knowing this, these errors can be undermined by us as developers.