### PR TITLE
implementing StandardJS static testing

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -12,9 +12,10 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
-        "test": "standard && node my-tests.js && npx tsc && nyc --reporter=html --reporter=text-summary mocha",
+        "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
+        "testStandardJS": "standard && node my-tests.js"
     },
     "nyc": {
         "exclude": [

--- a/install/package.json
+++ b/install/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
-        "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
+        "test": "standard && node my-tests.js && npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
     },
@@ -129,6 +129,7 @@
         "sortablejs": "1.15.0",
         "spdx-license-list": "6.6.0",
         "spider-detector": "2.0.0",
+        "standard": "*",
         "terser-webpack-plugin": "5.3.6",
         "textcomplete": "0.18.2",
         "textcomplete.contenteditable": "0.1.1",


### PR DESCRIPTION
added npx standard to package.json by editing "scripts" and "dependencies" lines

this PR should allow for static testing of code quality


<img width="973" alt="Screenshot 2024-03-14 at 5 50 45 PM" src="https://github.com/CMU-313/spring24-nodebb-ratramen/assets/147671684/dbd7cb7d-17b6-480e-bad0-97e5e0bcf010">
