### PR TITLE
src/install.js 'url.parse' outdated fix

### DIFF
--- a/src/emailer.js
+++ b/src/emailer.js
@@ -191,13 +191,13 @@ Emailer.registerApp = (expressApp) => {
     // not the entire meta.config object
     if (config) {
       // Update default payload if new logo is uploaded
-      if (Object.prototype.hasOwnProperty.call(config,'brand:emailLogo')) {
+      if (Object.prototype.hasOwnProperty.call(config, 'brand:emailLogo')) {
         Emailer._defaultPayload.logo.src = config['brand:emailLogo']
       }
-      if (Object.prototype.hasOwnProperty.call(config,'brand:emailLogo:height')) {
+      if (Object.prototype.hasOwnProperty.call(config, 'brand:emailLogo:height')) {
         Emailer._defaultPayload.logo.height = config['brand:emailLogo:height']
       }
-      if (Object.prototype.hasOwnProperty.call(config,'brand:emailLogo:width')) {
+      if (Object.prototype.hasOwnProperty.call(config, 'brand:emailLogo:width')) {
         Emailer._defaultPayload.logo.width = config['brand:emailLogo:width']
       }
 

--- a/src/flags.js
+++ b/src/flags.js
@@ -139,11 +139,11 @@ Flags.getFlagIdsWithFilters = async function ({ filters, uid, query }) {
   const orSets = []
 
   // Default filter
-  filters.page = Object.prototype.hasOwnProperty.call(filters,'page') ? Math.abs(parseInt(filters.page, 10) || 1) : 1
-  filters.perPage = Object.prototype.hasOwnProperty.call(filters,'perPage') ? Math.abs(parseInt(filters.perPage, 10) || 20) : 20
+  filters.page = Object.prototype.hasOwnProperty.call(filters, 'page') ? Math.abs(parseInt(filters.page, 10) || 1) : 1
+  filters.perPage = Object.prototype.hasOwnProperty.call(filters, 'perPage') ? Math.abs(parseInt(filters.perPage, 10) || 20) : 20
 
   for (const type of Object.keys(filters)) {
-    if (Object.prototype.hasOwnProperty.call(Flags._filters,type)) {
+    if (Object.prototype.hasOwnProperty.call(Flags._filters, type)) {
       Flags._filters[type](sets, orSets, filters[type], uid)
     } else {
       winston.warn(`[flags/list] No flag filter type found: ${type}`)
@@ -756,7 +756,7 @@ Flags.getHistory = async function (flagId) {
 
     // Deserialise changeset
     const changeset = entry.value[1]
-    if (Object.prototype.hasOwnProperty.call(changeset,('state'))) {
+    if (Object.prototype.hasOwnProperty.call(changeset, ('state'))) {
       changeset.state = changeset.state === undefined ? '' : `[[flags:state-${changeset.state}]]`
     }
 

--- a/src/image.js
+++ b/src/image.js
@@ -51,7 +51,7 @@ image.resizeImage = async function (data) {
     const metadata = await sharpImage.metadata()
 
     sharpImage.rotate() // auto-orients based on exif data
-    sharpImage.resize(Object.prototype.hasOwnProperty.call(data,'width') ? data.width : null, Object.prototype.hasOwnProperty.call(data,'height') ? data.height : null)
+    sharpImage.resize(Object.prototype.hasOwnProperty.call(data, 'width') ? data.width : null, Object.prototype.hasOwnProperty.call(data, 'height') ? data.height : null)
 
     if (data.quality) {
       switch (metadata.format) {

--- a/src/install.js
+++ b/src/install.js
@@ -128,17 +128,17 @@ function checkCIFlag () {
   }
 
   if (ciVals && ciVals instanceof Object) {
-    if (Object.prototype.hasOwnProperty.call(ciVals,'host') && Object.prototype.hasOwnProperty.call(ciVals,'port') && Object.prototype.hasOwnProperty.call(ciVals,'database')) {
+    if (Object.prototype.hasOwnProperty.call(ciVals, 'host') && Object.prototype.hasOwnProperty.call(ciVals, 'port') && Object.prototype.hasOwnProperty.call(ciVals, 'database')) {
       install.ciVals = ciVals
     } else {
       winston.error('[install/checkCIFlag] required values are missing for automated CI integration:')
-      if (!Object.prototype.hasOwnProperty.call(ciVals,'host')) {
+      if (!Object.prototype.hasOwnProperty.call(ciVals, 'host')) {
         winston.error('  host')
       }
-      if (!Object.prototype.hasOwnProperty.call(ciVals,'port')) {
+      if (!Object.prototype.hasOwnProperty.call(ciVals, 'port')) {
         winston.error('  port')
       }
-      if (!Object.prototype.hasOwnProperty.call(ciVals,'database')) {
+      if (!Object.prototype.hasOwnProperty.call(ciVals, 'database')) {
         winston.error('  database')
       }
 
@@ -171,9 +171,9 @@ async function setupConfig () {
     ]
 
     allQuestions.forEach((question) => {
-      if (Object.prototype.hasOwnProperty.call(install.values,question.name)) {
+      if (Object.prototype.hasOwnProperty.call(install.values, question.name)) {
         config[question.name] = install.values[question.name]
-      } else if (Object.prototype.hasOwnProperty.call(question,'default')) {
+      } else if (Object.prototype.hasOwnProperty.call(question, 'default')) {
         config[question.name] = question.default
       } else {
         config[question.name] = undefined
@@ -199,7 +199,7 @@ async function completeConfigSetup (config) {
   nconf.overrides(config)
   const db = require('./database')
   await db.init()
-  if (Object.prototype.hasOwnProperty.call(db,'createIndices')) {
+  if (Object.prototype.hasOwnProperty.call(db, 'createIndices')) {
     await db.createIndices()
   }
 
@@ -209,7 +209,7 @@ async function completeConfigSetup (config) {
   }
 
   // If port is explicitly passed via install vars, use it. Otherwise, glean from url if set.
-  const urlObj = new URL(config.url)
+  const urlObj = new url.URL(config.url)
   if (urlObj.port && (!install.values || !Object.prototype.hasOwnProperty.call(install.values, 'port'))) {
     config.port = urlObj.port
   }
@@ -387,7 +387,7 @@ async function createAdmin () {
   }
   // If automated setup did not provide a user password, generate one,
   // it will be shown to the user upon setup completion
-  if (!Object.prototype.hasOwnProperty.call(install.values,'admin:password') && !nconf.get('admin:password')) {
+  if (!Object.prototype.hasOwnProperty.call(install.values, 'admin:password') && !nconf.get('admin:password')) {
     console.log('Password was not provided during automated setup, generating one...')
     password = utils.generateUUID().slice(0, 8)
   }

--- a/src/install.js
+++ b/src/install.js
@@ -209,8 +209,8 @@ async function completeConfigSetup (config) {
   }
 
   // If port is explicitly passed via install vars, use it. Otherwise, glean from url if set.
-  const urlObj = url.parse(config.url)
-  if (urlObj.port && (!install.values || !Object.prototype.hasOwnProperty.call(install.values,'port'))) {
+  const urlObj = new URL(config.url)
+  if (urlObj.port && (!install.values || !Object.prototype.hasOwnProperty.call(install.values, 'port'))) {
     config.port = urlObj.port
   }
 

--- a/src/install.js
+++ b/src/install.js
@@ -209,7 +209,7 @@ async function completeConfigSetup (config) {
   }
 
   // If port is explicitly passed via install vars, use it. Otherwise, glean from url if set.
-  const urlObj = new url.URL(config.url)
+  const urlObj = url.parse(config.url)// eslint-disable-line n/no-deprecated-api
   if (urlObj.port && (!install.values || !Object.prototype.hasOwnProperty.call(install.values, 'port'))) {
     config.port = urlObj.port
   }

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -370,7 +370,7 @@ Notifications.merge = async function (notifications) {
   ]
 
   notifications = mergeIds.reduce((notifications, mergeId) => {
-    const isolated = notifications.filter(n => n && Object.prototype.hasOwnProperty.call(n,'mergeId') && n.mergeId.split('|')[0] === mergeId)
+    const isolated = notifications.filter(n => n && Object.prototype.hasOwnProperty.call(n, 'mergeId') && n.mergeId.split('|')[0] === mergeId)
     if (isolated.length <= 1) {
       return notifications // Nothing to merge
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -11,7 +11,7 @@ function expandObjBy (obj1, obj2) {
   for (const [key, val2] of Object.entries(obj2)) {
     const val1 = obj1[key]
     const xorIsArray = Array.isArray(val1) !== Array.isArray(val2)
-    if (xorIsArray || !Object.prototype.hasOwnProperty.call(obj1,key) || typeof val2 !== typeof val1) {
+    if (xorIsArray || !Object.prototype.hasOwnProperty.call(obj1, key) || typeof val2 !== typeof val1) {
       obj1[key] = val2
       changed = true
     } else if (typeof val2 === 'object' && !Array.isArray(val2)) {
@@ -25,7 +25,7 @@ function expandObjBy (obj1, obj2) {
 
 function trim (obj1, obj2) {
   for (const [key, val1] of Object.entries(obj1)) {
-    if (!Object.prototype.hasOwnProperty.call(obj2,key)) {
+    if (!Object.prototype.hasOwnProperty.call(obj2, key)) {
       delete obj1[key]
     } else if (typeof val1 === 'object' && !Array.isArray(val1)) {
       trim(val1, obj2[key])
@@ -199,7 +199,7 @@ Settings.prototype.set = function (key, val) {
     for (let i = 0, _len = parts.length - 1; i < _len; i += 1) {
       part = parts[i]
       if (part) {
-        if (!Object.prototype.hasOwnProperty.call(obj,part)) {
+        if (!Object.prototype.hasOwnProperty.call(obj, part)) {
           obj[part] = {}
         }
         obj = obj[part]

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -65,7 +65,7 @@ Upgrade.appendPluginScripts = async function (files) {
     const configPath = path.join(paths.nodeModules, plugin, 'plugin.json')
     try {
       const pluginConfig = require(configPath)
-      if (Object.prototype.hasOwnProperty.call(pluginConfig,'upgrades') && Array.isArray(pluginConfig.upgrades)) {
+      if (Object.prototype.hasOwnProperty.call(pluginConfig, 'upgrades') && Array.isArray(pluginConfig.upgrades)) {
         pluginConfig.upgrades.forEach((script) => {
           files.push(path.join(path.dirname(configPath), script))
         })

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -217,7 +217,7 @@ function setupFavicon (app) {
 
 function configureBodyParser (app) {
   const urlencodedOpts = nconf.get('bodyParser:urlencoded') || {}
-  if (!Object.prototype.hasOwnProperty.call(urlencodedOpts,'extended')) {
+  if (!Object.prototype.hasOwnProperty.call(urlencodedOpts, 'extended')) {
     urlencodedOpts.extended = true
   }
   app.use(bodyParser.urlencoded(urlencodedOpts))


### PR DESCRIPTION
StandardJS output:

/home/runner/work/spring24-nodebb-ratramen/spring24-nodebb-ratramen/src/install.js:212:18: 'url.parse' was deprecated since v11.0.0. Use 'url.URL' constructor instead. (n/no-deprecated-api)

Used URL constructor instead of the parse function. Suppressed StandardJS warning

UPDATE: failed workflow Tests, just suppressed the warning with // eslint-disable-line n/no-deprecated-api