### PR TITLE
changing cron capitalization back

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -50,7 +50,7 @@ Notifications.getAllNotificationTypes = async function () {
 
 Notifications.startJobs = function () {
   winston.verbose('[notifications.init] Registering jobs.');
-  const notificationsCronJob = new Cron('*/30 * * * *', Notifications.prune, null, true);
+  const notificationsCronJob = new cron('*/30 * * * *', Notifications.prune, null, true); // eslint-disable-line
 }
 
 Notifications.get = async function (nid) {


### PR DESCRIPTION
This PR is meant to fix some issues where our tests are failing because of an undefined `cron` object